### PR TITLE
Fix gl.run.popcluster ancestry parsing for population names with spaces or multi-byte characters

### DIFF
--- a/R/gl.run.popcluster.r
+++ b/R/gl.run.popcluster.r
@@ -502,39 +502,49 @@ gl.run.popcluster <- function(x,
     
     best <- readLines(con <- file(file.path(tempd, i)))
     close(con)
-    Q_raw <- stringr::str_split(best[(which(startsWith(
-      best, "Inferred ancestry of individuals"
-    )) + 2):(which(startsWith(
-      best, "Inferred ancestry of individuals"
-    )) + 1 + nInd(x))], " ")
-    
-    for (j in 1:length(Q_raw)) {
-      Q_raw[[j]][which(Q_raw[[j]] == "")] <- NA
-      Q_raw[[j]][which(Q_raw[[j]] == ":")] <- NA
-      Q_raw[[j]] <- na.omit(Q_raw[[j]])
-      Q <- data.frame(rbind(Q, Q_raw[[j]]))
-    }
-    
-      Q <- Q[,-(4:5)]
-    
+    hdr <- which(startsWith(best, "Inferred ancestry of individuals"))
+    anc_lines <- best[(hdr + 2):(hdr + 1 + nInd(x))]
+
+    # Each ancestry line has the layout
+    #   Index Order <PopName...> %Miss Cluster : prop_1 prop_2 ... prop_K
+    # The <PopName> column is the genlight population label and may contain
+    # spaces (e.g. "Upper Murray") or wide multi-byte characters (e.g. the
+    # en-dash in "Macquarie-Castlereagh"), so the number of whitespace tokens
+    # varies between individuals. Anchor on the ":" and read Index/Order from
+    # the front and %Miss/Cluster from the back, so parsing never depends on
+    # the (variable) token count of the middle. The previous approach split on
+    # spaces and used fixed positional columns, which misaligned these rows and
+    # recycled the Index into the last cluster, producing ancestry values > 1.
+    Q_rows <- lapply(anc_lines, function(line) {
+      sp    <- strsplit(line, ":", fixed = TRUE)[[1]]
+      left  <- strsplit(trimws(sp[1]), "\\s+")[[1]]
+      props <- as.numeric(strsplit(trimws(sp[2]), "\\s+")[[1]])
+      n <- length(left)
+      data.frame(
+        Index       = as.integer(left[1]),
+        Order       = as.integer(left[2]),
+        PercentMiss = left[n - 1],
+        Cluster     = left[n],
+        t(props),
+        stringsAsFactors = FALSE
+      )
+    })
+    Q <- do.call(rbind, Q_rows)
     colnames(Q) <- c("Index",
                      "Order",
-                     "Label",
                      "PercentMiss",
                      "Cluster",
-                     paste0("Pop_", seq(1, (ncol(
-                       Q
-                     ) - 5), by = 1)))
-    Q$Label <- sample_name[as.integer(Q$Index)]
+                     paste0("Pop_", seq_len(ncol(Q) - 4)))
+    Q$Label <- sample_name[Q$Index]
     Q$Cluster <- as.character(Q$Cluster)
     Q$Pop <- as.character(x$pop)
+    # restore the documented column order
+    Q <- Q[, c("Index", "Order", "Label", "PercentMiss", "Cluster",
+               paste0("Pop_", seq_len(sum(startsWith(names(Q), "Pop_")))),
+               "Pop")]
     # change the Order
     Q <- Q[with(Q, order(Q$Pop, as.numeric(Q$Cluster))), ]
     Q$Order <- 1:nrow(Q)
-    Q <- Q %>%
-      mutate_at(paste0("Pop_", seq(1, (ncol(
-        Q
-      ) - 6), by = 1)), as.numeric)
     Q_matrices[[i]] <- Q
     Q <- NULL
   }


### PR DESCRIPTION
## Problem

`gl.plot.popcluster` rendered ancestry bars as thin strips at the bottom of the panel instead of full-height stacked bars, with a few inflated bars dominating the plot.

The plot function was faithful — the corruption originated in `gl.run.popcluster`. The ancestry section of each PopCluster best-run file was parsed by splitting lines on single spaces and using fixed positional columns (`Q[,-(4:5)]`). The per-individual label written to PopCluster is the **genlight population name**, so names containing:

- a **space** (e.g. `Upper Murray`, `Pambula Richmond`), or
- a **wide multi-byte character** (e.g. the en-dash in `Macquarie–Castlereagh`, which fills the fixed-width field and absorbs the adjacent `PopFlag`)

produced a different number of whitespace tokens. `data.frame(rbind(Q, vec))` then **recycled** the mismatched-length vector instead of erroring, shifting columns and dumping the `Index` value into the last cluster column (`Pop_K`) — ancestry values up to **54**. Since the plot lets ggplot autoscale the y-axis, one bar stacking to ~54 squashed every correct (sum = 1) bar into a thin strip.

## Fix

Anchor the parse on the `:` separator: `Index`/`Order` from the front, `%Miss`/`Cluster` from the back, and the K proportions from after the colon — so parsing no longer depends on the (variable) token count of the population-name column.

## Verification

- Failing test on the real raw output file: old parser → 16/61 rows corrupt (max value 54); new parser → 0 corrupt, all rows sum to 1.
- End-to-end re-run (K = 1–4): every per-K Q matrix has rows summing to 1, max value ≤ 1.
- Structure barplot now renders full-height stacked bars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)