### PR TITLE
fix bug in gl.nhybrids: aa-PofZ.csv columns mislabelled, NULL-directory path crashed

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,18 @@
+# dartR.popgen (development version)
+
+## Bug fixes
+
+* `gl.nhybrids`: the results table `aa-PofZ.csv` no longer mislabels the
+  posterior-probability columns. Previously the NewHybrids `IndivName`
+  column was kept, so `P0` held the string "NoName" and every probability
+  sat one column to the right of its label. **Values read from the labelled
+  columns of `aa-PofZ.csv` change for all users.**
+* `gl.nhybrids`: `nhyb.directory = NULL` (write the input file and stop)
+  no longer errors on macOS/Linux.
+* `gl.nhybrids`: a NewHybrids run that produces no output now stops with a
+  clear error instead of failing cryptically or silently reusing a previous
+  run's results; paths of 100+ characters, which crash the NewHybrids
+  binary, are rejected with an explanation; `aa-Pi.hist` is now delivered
+  to `outpath`; the caller's working directory is restored on failure; and
+  `loc.metrics` in the returned object now track the selected loci
+  positionally.

--- a/R/gl.nhybrids.r
+++ b/R/gl.nhybrids.r
@@ -61,8 +61,8 @@
 #' [default two colors].
 #' @param pprob Threshold level for assignment to likelihood bins
 #' [default 0.95, used only if plot=TRUE].
-#' @param method Specifies the method (random) to select 200 loci for
-#'  NewHybrids [default random]. Previous AvgPic does not work anymore!
+#' @param method Currently has no effect: loci are always selected at
+#' random. Retained for back-compatibility [default random].
 #' @param nhyb.directory Directory that holds the NewHybrids executable file
 #' e.g. C:/NewHybsPC [default NULL].
 #' @param BurnIn Number of sweeps to use in the burn in [default 10000].
@@ -80,7 +80,7 @@
 #' progress log; 3, progress and results summary; 5, full report
 #' [default 2 or as specified using gl.set.verbosity].
 #' @return The reduced genlight object, if parentals are provided; output of
-#'  NewHybrids is saved to the working directory.
+#'  NewHybrids is saved to outpath [default tempdir()].
 #' @export
 #' @importFrom MASS write.matrix
 #' @references Anderson, E.C. and Thompson, E.A.(2002). A model-based method for identifying
@@ -124,7 +124,6 @@ gl.nhybrids <- function(gl,
   funname <- match.call()[[1]]
   utils.flag.start(
     func = funname,
-    build = "Jody",
     verbose = verbose
   )
 
@@ -151,6 +150,24 @@ gl.nhybrids <- function(gl,
     pprob <- 0.99
   }
 
+  # Normalize the priors once, before the OS split. The NewHybrids binary
+  # accepts the exact spellings "Jeffreys" and "uniform"; anything else makes
+  # it exit without producing output, so reject other values here.
+  if (PiPrior %in% c("Jeffreys", "jeffreys")) {
+    PiPrior <- "Jeffreys"
+  } else if (PiPrior %in% c("Uniform", "uniform")) {
+    PiPrior <- "Uniform"
+  } else {
+    stop(error("Fatal Error: PiPrior parameter must be Jeffreys or Uniform\n"))
+  }
+  if (ThetaPrior %in% c("Jeffreys", "jeffreys")) {
+    ThetaPrior <- "Jeffreys"
+  } else if (ThetaPrior %in% c("Uniform", "uniform")) {
+    ThetaPrior <- "Uniform"
+  } else {
+    stop(error("Fatal Error: ThetaPrior parameter must be Jeffreys or Uniform\n"))
+  }
+
   # Housekeeping on the outfile specifications
   outfile <- "nhyb.txt"
   outfile <- file.path(outpath, outfile)
@@ -159,6 +176,9 @@ gl.nhybrids <- function(gl,
     nhyb.directory.win <- gsub("/", "\\\\", nhyb.directory)
     wd.hold <- getwd()
     wd.hold.win <- gsub("/", "\\\\", wd.hold)
+    # restore the caller's working directory however this function exits;
+    # both OS blocks setwd() into nhyb.directory to run the executable
+    on.exit(setwd(wd.hold), add = TRUE)
   }
 
   # DO THE JOB
@@ -297,8 +317,10 @@ gl.nhybrids <- function(gl,
             verbose = 0
           )
         gl2nhyb <- cbind(gl.fixed.used, tmp)
+        # positional subset: cbind orders loci as [fixed, supplement], so the
+        # metrics rows must be picked in that order, not the original one
         gl2nhyb@other$loc.metrics <-
-          gl@other$loc.metrics[locNames(gl) %in% locNames(gl2nhyb), ]
+          gl@other$loc.metrics[match(locNames(gl2nhyb), locNames(gl)), ]
       # } else {
       #   if (verbose >= 3) {
       #     cat(
@@ -373,10 +395,10 @@ gl.nhybrids <- function(gl,
         "loci with most information content (AvgPIC)\n"
       )
     }
+    # gl.subsample.loc already subsets loc.metrics in the sampled order;
+    # re-subsetting here in the original order desynced metrics from loci
     gl2nhyb <-
       gl.subsample.loc(gl, loc.limit, replace = FALSE, verbose = 0)
-    gl2nhyb@other$loc.metrics <-
-      gl@other$loc.metrics[locNames(gl) %in% locNames(gl2nhyb), ]
     flag <- "onepar"
   }
 
@@ -398,9 +420,9 @@ gl.nhybrids <- function(gl,
         )
       )
     }
+    # gl.subsample.loc already subsets loc.metrics in the sampled order;
+    # re-subsetting here in the original order desynced metrics from loci
     gl2nhyb <- gl.subsample.loc(gl, loc.limit, replace = FALSE, verbose = 0)
-    gl2nhyb@other$loc.metrics <-
-      gl@other$loc.metrics[locNames(gl) %in% locNames(gl2nhyb), ]
     flag <- "nopar"
   }
 
@@ -487,17 +509,19 @@ gl.nhybrids <- function(gl,
     }
 
     # Check the installation of New Hybrids
-    tmp1 <- file.exists(paste0(nhyb.directory.win, "/NewHybrids_PC_1_1_WOG.exe"))
-    if (!tmp1) {
-      stop(error("Fatal Error: New Hybrids executable not found in", nhyb.directory.win, "; required\n"))
-    }
-    tmp2 <- file.exists(paste0(nhyb.directory.win, "/TwoGensGtypFreq.txt"))
-    if (!tmp2) {
-      stop(error("Fatal Error: New Hybrids Genotype Frequency file not found in", nhyb.directory.win, "; required\n"))
-    }
-    if (verbose >= 2) {
-      if (tmp1 & tmp2) {
-        cat(report("  New Hybrids executable files found\n"))
+    if (!is.null(nhyb.directory)) {
+      tmp1 <- file.exists(paste0(nhyb.directory.win, "/NewHybrids_PC_1_1_WOG.exe"))
+      if (!tmp1) {
+        stop(error("Fatal Error: New Hybrids executable not found in", nhyb.directory.win, "; required\n"))
+      }
+      tmp2 <- file.exists(paste0(nhyb.directory.win, "/TwoGensGtypFreq.txt"))
+      if (!tmp2) {
+        stop(error("Fatal Error: New Hybrids Genotype Frequency file not found in", nhyb.directory.win, "; required\n"))
+      }
+      if (verbose >= 2) {
+        if (tmp1 & tmp2) {
+          cat(report("  New Hybrids executable files found\n"))
+        }
       }
     }
 
@@ -573,15 +597,28 @@ gl.nhybrids <- function(gl,
       cat(") | NewHybrids_PC_1_1_WOG.exe")
       sink()
 
-      # Run New Hybrids
+      # Run New Hybrids. Remove any aa-PofZ.txt left by an earlier
+      # interrupted run so a failed run cannot silently return stale results,
+      # and stop with a clear message when the executable does not complete.
+      if (file.exists("aa-PofZ.txt")) {
+        tmp <- file.remove("aa-PofZ.txt")
+      }
+      status <- system("nhyb.cmd")
 
-      system("nhyb.cmd")
+      # newhybs exits with a non-zero status even on a successful run, so
+      # completion is judged by the presence of its output file
+      if (!file.exists("aa-PofZ.txt")) {
+        stop(error(
+          "Fatal Error: NewHybrids did not complete (exit status", status,
+          ") and produced no aa-PofZ.txt. Check the console output above for the cause.\n"
+        ))
+      }
 
-      # Add in individual labels
+      # Add in individual labels. aa-PofZ.txt columns are: index, IndivName,
+      # then the six category probabilities - drop the first two.
       tbl <-
         read.table("aa-PofZ.txt", stringsAsFactors = FALSE)
-      names(tbl) <- tbl[1, ]
-      tbl <- tbl[-1, -1]
+      tbl <- tbl[-1, -(1:2)]
       tbl <- cbind(indNames(gl), pop(gl), tbl)
       names(tbl) <-
         c("id", "pop", "P0", "P1", "F1", "F2", "F1xP0", "F1xP1")
@@ -598,7 +635,7 @@ gl.nhybrids <- function(gl,
       tmp <- file.copy(from = "aa-ProcessedPriors.txt", to = outpath, overwrite = TRUE)
       tmp <- file.remove("aa-ProcessedPriors.txt")
 
-      tmp <- file.copy(from = "aa-Pi.hist", to = nhyb.directory.win, overwrite = TRUE)
+      tmp <- file.copy(from = "aa-Pi.hist", to = outpath, overwrite = TRUE)
       tmp <- file.remove("aa-Pi.hist")
 
       tmp <- file.copy(from = "aa-PofZ.csv", to = outpath, overwrite = TRUE)
@@ -612,7 +649,6 @@ gl.nhybrids <- function(gl,
       tmp <- file.remove("nhyb.cmd")
 
       setwd(wd.hold)
-      on.exit(setwd(wd.hold))
     }
   } ##### END WINDOWS BLOCK
 
@@ -653,7 +689,10 @@ gl.nhybrids <- function(gl,
       }
     }
 
-    if (grepl("\\s", outfile.mac) | grepl("\\s", nhyb.directory)) {
+    # nhyb.directory may be NULL (write the input file and stop) - guard the
+    # space check or grepl() on NULL crashes the documented NULL path
+    if (grepl("\\s", outfile.mac) ||
+      (!is.null(nhyb.directory) && grepl("\\s", nhyb.directory))) {
       stop(
         error(
           "Fatal Error: The path to the executable for NewHybrids or the outfile name has spaces. Please move it to a path without spaces or choose a file name without spaces.\n"
@@ -667,18 +706,20 @@ gl.nhybrids <- function(gl,
     }
 
     # Check the installation of New Hybrids
-    tmp1 <- file.exists(paste0(nhyb.directory.mac, "/newhybs"))
-    if (!tmp1) {
-      stop(error("Fatal Error: New Hybrids executable not found in", nhyb.directory.mac, "; required\n"))
-    }
-    # tmp2 <- file.exists(paste0(nhyb.directory.mac,"/TwoGensGtypFreq.txt"))
-    # if(!tmp2){
-    #   stop(error("Fatal Error: New Hybrids Genotype Frequency file not found in",nhyb.directory.win,"; required\n"))
-    # }
-    if (verbose >= 2) {
-      # if(tmp1 & tmp2){
-      if (tmp1) {
-        cat(report("  New Hybrids executable files found\n"))
+    if (!is.null(nhyb.directory)) {
+      tmp1 <- file.exists(paste0(nhyb.directory.mac, "/newhybs"))
+      if (!tmp1) {
+        stop(error("Fatal Error: New Hybrids executable not found in", nhyb.directory.mac, "; required\n"))
+      }
+      # tmp2 <- file.exists(paste0(nhyb.directory.mac,"/TwoGensGtypFreq.txt"))
+      # if(!tmp2){
+      #   stop(error("Fatal Error: New Hybrids Genotype Frequency file not found in",nhyb.directory.win,"; required\n"))
+      # }
+      if (verbose >= 2) {
+        # if(tmp1 & tmp2){
+        if (tmp1) {
+          cat(report("  New Hybrids executable files found\n"))
+        }
       }
     }
 
@@ -720,23 +761,53 @@ gl.nhybrids <- function(gl,
       rand1 <- sample(1:10, 1)
       rand2 <- sample(11:20, 1)
 
-      system(paste(
+      # The newhybs binary reads the data-file path into a fixed ~100-byte
+      # buffer and aborts (SIGILL, no message) on paths of 100+ characters
+      data.file <- paste0(nhyb.directory.mac, "/", basename(outfile))
+      if (nchar(data.file) >= 100) {
+        stop(error(
+          "Fatal Error: the path to the NewHybrids input file (", data.file,
+          ") is", nchar(data.file),
+          "characters long; the NewHybrids executable crashes on paths of 100 or more characters. Use a shorter nhyb.directory.\n"
+        ))
+      }
+
+      # The binary accepts the exact spellings "Jeffreys" and "uniform"
+      pi.prior.arg <- ifelse(PiPrior == "Uniform", "uniform", "Jeffreys")
+      theta.prior.arg <- ifelse(ThetaPrior == "Uniform", "uniform", "Jeffreys")
+
+      # Remove any aa-PofZ.txt left by an earlier interrupted run so a failed
+      # run cannot silently return stale results
+      if (file.exists("aa-PofZ.txt")) {
+        tmp <- file.remove("aa-PofZ.txt")
+      }
+
+      status <- system(paste(
         paste0(nhyb.directory.mac, "/newhybs"),
         "--no-gui",
-        "--data-file", paste0(nhyb.directory.mac, "/", basename(outfile)),
+        "--data-file", data.file,
         "--seeds", rand1, rand2,
-        "--pi-prior", PiPrior,
-        "--theta-prior", ThetaPrior,
+        "--pi-prior", pi.prior.arg,
+        "--theta-prior", theta.prior.arg,
         "--burn-in", BurnIn,
         "--num-sweeps", sweeps
         # "--gtyp-cat-file",GtypFile,
       ))
 
-      # Add in individual labels
+      # newhybs exits with a non-zero status even on a successful run, so
+      # completion is judged by the presence of its output file
+      if (!file.exists("aa-PofZ.txt")) {
+        stop(error(
+          "Fatal Error: NewHybrids did not complete (exit status", status,
+          ") and produced no aa-PofZ.txt. Check the console output above for the cause.\n"
+        ))
+      }
+
+      # Add in individual labels. aa-PofZ.txt columns are: index, IndivName,
+      # then the six category probabilities - drop the first two.
       tbl <-
         read.table("aa-PofZ.txt", stringsAsFactors = FALSE)
-      names(tbl) <- tbl[1, ]
-      tbl <- tbl[-1, -1]
+      tbl <- tbl[-1, -(1:2)]
       tbl <- cbind(indNames(gl), pop(gl), tbl)
       names(tbl) <-
         c("id", "pop", "P0", "P1", "F1", "F2", "F1xP0", "F1xP1")
@@ -753,7 +824,7 @@ gl.nhybrids <- function(gl,
       # tmp <- file.copy(from="aa-ProcessedPriors.txt", to=outpath, overwrite = TRUE)
       # tmp <- file.remove("aa-ProcessedPriors.txt")
 
-      tmp <- file.copy(from = "aa-Pi.hist", to = nhyb.directory.mac, overwrite = TRUE)
+      tmp <- file.copy(from = "aa-Pi.hist", to = outpath, overwrite = TRUE)
       tmp <- file.remove("aa-Pi.hist")
 
       tmp <- file.copy(from = "aa-PofZ.csv", to = outpath, overwrite = TRUE)
@@ -778,7 +849,8 @@ gl.nhybrids <- function(gl,
 
   ##### Analyse the F1 genotypes
 
-  if (flag == "bothpar" & plot == TRUE) {
+  # aa-PofZ.csv only exists when NewHybrids was actually run
+  if (flag == "bothpar" & plot == TRUE & !is.null(nhyb.directory)) {
     # Read in the results of the New Hybrids analysis
     F1.test <- read.csv(file = paste0(outpath,"/aa-PofZ.csv"))
     # Pull out results for F1 hybrids only, defined by posterior probability >= pprob
@@ -857,7 +929,11 @@ gl.nhybrids <- function(gl,
 
   # if (verbose < 2) {sink()}
   if (verbose >= 3) {
-    cat(report("  Results are stored in file aa-PofZ.csv\n"))
+    if (!is.null(nhyb.directory)) {
+      cat(report("  Results are stored in file aa-PofZ.csv\n"))
+    } else {
+      cat(report("  NewHybrids input file written; no directory for the executable was supplied, so NewHybrids was not run\n"))
+    }
     cat(
       report(
         "  Returning data used by New Hybrids in generating the results, as a genlight object\n"

--- a/R/gl.nhybrids.r
+++ b/R/gl.nhybrids.r
@@ -85,7 +85,7 @@
 #' @importFrom MASS write.matrix
 #' @references Anderson, E.C. and Thompson, E.A.(2002). A model-based method for identifying
 #' species hybrids using multilocus genetic data. Genetics. 160:1217-1229.
-#' @author Custodian: Arthur Georges -- Post to
+#' @author Author(s): Arthur Georges. Custodian: Arthur Georges -- Post to
 #'  \url{https://groups.google.com/d/forum/dartr}
 #' @examples
 #' \dontrun{

--- a/man/gl.nhybrids.Rd
+++ b/man/gl.nhybrids.Rd
@@ -142,6 +142,6 @@ Anderson, E.C. and Thompson, E.A.(2002). A model-based method for identifying
 species hybrids using multilocus genetic data. Genetics. 160:1217-1229.
 }
 \author{
-Custodian: Arthur Georges -- Post to
+Author(s): Arthur Georges. Custodian: Arthur Georges -- Post to
  \url{https://groups.google.com/d/forum/dartr}
 }

--- a/man/gl.nhybrids.Rd
+++ b/man/gl.nhybrids.Rd
@@ -40,8 +40,8 @@ gl.nhybrids(
 \item{threshold}{Sets the level at which a gene frequency difference is
 considered to be fixed [default 0].}
 
-\item{method}{Specifies the method (random) to select 200 loci for
-NewHybrids [default random]. Previous AvgPic does not work anymore!}
+\item{method}{Currently has no effect: loci are always selected at
+random. Retained for back-compatibility [default random].}
 
 \item{plot}{If TRUE, a plot of the frequency of homozygous reference,
 heterozygotes and homozygous alternate (SNP) is produced for the F1
@@ -82,7 +82,7 @@ progress log; 3, progress and results summary; 5, full report
 }
 \value{
 The reduced genlight object, if parentals are provided; output of
- NewHybrids is saved to the working directory.
+ NewHybrids is saved to outpath [default tempdir()].
 }
 \description{
 This function compares two sets of parental populations to identify loci that

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(dartR.popgen)
+
+test_check("dartR.popgen")

--- a/tests/testthat/test-gl.nhybrids.R
+++ b/tests/testthat/test-gl.nhybrids.R
@@ -1,0 +1,53 @@
+# Characterization baseline for gl.nhybrids (function-review campaign).
+# Snapshots what the function does today; it does not assert correctness.
+
+test_that("input-file-only path (nhyb.directory = NULL) on Unix", {
+  skip_on_os("windows")
+  gl <- dartR.data::testset.gl
+  out <- withr::local_tempdir()
+  set.seed(42)
+  # Post-fix behaviour (approved change 2, review report F2): with
+  # nhyb.directory = NULL the function writes the input file and returns
+  # the reduced genlight as documented.
+  res <- gl.nhybrids(gl,
+    p0 = NULL, p1 = NULL,
+    nhyb.directory = NULL,
+    outpath = out,
+    verbose = 0
+  )
+  expect_s4_class(res, "genlight")
+  expect_equal(nLoc(res), 200)
+  expect_equal(nInd(res), nInd(gl))
+  # loc.metrics track the sampled loci positionally (approved change 7 / F7)
+  expect_equal(nrow(res@other$loc.metrics), nLoc(res))
+  ids <- sub("\\|.*", "", as.character(res@other$loc.metrics$AlleleID))
+  expect_equal(ids, sub("-.*", "", locNames(res)))
+  hdr <- readLines(file.path(out, "nhyb.txt"), n = 3)
+  expect_match(hdr[1], "^NumIndivs\\s+250")
+  expect_match(hdr[2], "^NumLoci\\s+200")
+})
+
+test_that("execution path builds aa-PofZ.csv (requires newhybs binary)", {
+  bin_dir <- Sys.getenv("NEWHYBS_DIR", "")
+  skip_if(bin_dir == "" || !file.exists(file.path(bin_dir, "newhybs")),
+          "newhybs binary not available (set NEWHYBS_DIR)")
+  gl <- dartR.data::testset.gl
+  out <- withr::local_tempdir()
+  set.seed(42)
+  res <- gl.nhybrids(gl,
+    p0 = NULL, p1 = NULL,
+    nhyb.directory = bin_dir,
+    outpath = out,
+    BurnIn = 50, sweeps = 50,
+    verbose = 0
+  )
+  pofz <- read.csv(file.path(out, "aa-PofZ.csv"))
+  expect_equal(nrow(pofz), nInd(gl))
+  # Post-fix contract (approved change 1, review report F1): id, pop, then
+  # the six NewHybrids category probabilities, correctly labelled.
+  expect_equal(names(pofz),
+               c("id", "pop", "P0", "P1", "F1", "F2", "F1xP0", "F1xP1"))
+  probs <- pofz[, c("P0", "P1", "F1", "F2", "F1xP0", "F1xP1")]
+  expect_true(all(vapply(probs, is.numeric, logical(1))))
+  expect_true(all(abs(rowSums(probs) - 1) < 0.01))
+})


### PR DESCRIPTION
## What changed
- drop the IndivName column when parsing aa-PofZ.txt so aa-PofZ.csv has eight correctly labelled columns, both OS blocks (F1)
- guard the Unix space check and executable checks so `nhyb.directory = NULL` writes the input file and returns the reduced genlight as documented (F2)
- pre-delete stale aa-PofZ.txt and stop with a clear error when NewHybrids produces no output (F3)
- reject data-file paths of 100+ characters, which crash the newhybs binary, with an explanatory error (F4)
- register `on.exit(setwd(wd.hold))` before the first `setwd()` so the caller's working directory is restored on failure (F5)
- deliver aa-Pi.hist to `outpath` instead of copying it onto itself and deleting it (F6)
- fix loc.metrics/loci desync at three sites: two redundant overwrites after `gl.subsample.loc` removed, the cbind path reordered with `match()` (F7, scope extension approved)
- normalize and validate PiPrior/ThetaPrior before the OS split; Unix passes the binary-accepted spellings (F8)
- docs: `method` currently has no effect, `@return` names `outpath`; outdated `build=` argument dropped (F9, F10)

## Why
The results table was wrong for every user: aa-PofZ.txt has index, IndivName, then six probabilities, but only the index was dropped, so `P0` held the string "NoName" and each probability sat one column right of its label. Separately, the documented write-and-stop mode (`nhyb.directory = NULL`) crashed on macOS/Linux with "argument is of length zero", and a failed NewHybrids run either surfaced as "cannot open the connection" or silently returned a previous run's stale results.

## Evidence
- End-to-end run on testset.gl with the real newhybs binary: before, aa-PofZ.csv header `id,pop,P0,P1,F1,F2,F1xP0,F1xP1,NA` with `P0 == "NoName"`; after, eight labelled columns, all probability columns numeric, rows sum to 1.
- Characterization tests added (`tests/` did not exist): 11/11 pass; the two baseline diffs (NULL-path crash → normal return; nine-column CSV → eight) map to approved changes 2 and 1.
- Failing-binary case: clear "NewHybrids did not complete (exit status 1)" error. The binary exits 1 even on success, so completion is gated on the output file, with the status reported.
- Path-length guard: 104-character path stops with the guard message; 99-character path still runs (empirical crash threshold: 99 ok, 100 SIGILL).
- loc.metrics alignment verified: AlleleID prefixes match locNames order in the returned object.
- Working directory restored after both success and failure runs.

## API impact
No signature change. **Values read from the labelled columns of aa-PofZ.csv change for all users** — previously each was the column to its left; approved with this consequence acknowledged, recorded in NEWS.md. Caller grep: dartR.* siblings reference `gl.nhybrids` only in docs (`gl.filter.pa`); the dartR Shiny app reads aa-PofZ.csv and needs no change.

## Review
Report: `function-review/reports/dartR.popgen/gl.nhybrids.md` (dartR.base checkout, function-review campaign). 10 findings; changes 1-9 all approved by Luis (change 1 with consequence acknowledged; F7 scope extension to three sites approved in-session).